### PR TITLE
Fixed shadow glitch on modals

### DIFF
--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -1,12 +1,19 @@
+import { mode } from "@chakra-ui/theme-tools"
+
+type Dict = Record<string, any>
+
 const styles = {
   parts: ["dialog", "closeButton", "header", "footer", "body"],
-  baseStyle: {
+  baseStyle: (props: Dict) => ({
     dialog: {
       borderTopRadius: "xl",
       borderBottomRadius: { base: 0, sm: "xl" },
       overflow: "hidden",
       marginTop: "auto",
       marginBottom: { base: 0, sm: "auto" },
+      ":focus:not([data-focus-visible-added])": {
+        boxShadow: mode("lg", "dark-lg")(props),
+      },
     },
     closeButton: {
       borderRadius: "full",
@@ -33,7 +40,7 @@ const styles = {
         w: "full",
       },
     },
-  },
+  }),
 }
 
 export default styles

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -11,6 +11,9 @@ const styles = {
       overflow: "hidden",
       marginTop: "auto",
       marginBottom: { base: 0, sm: "auto" },
+      // we can't add data attributes to the Modal component so we have
+      // to prevent the focus-visible polyfill from removing shadow on
+      // focus by overriding it's style with the default box-shadow
       ":focus:not([data-focus-visible-added])": {
         boxShadow: mode("lg", "dark-lg")(props),
       },


### PR DESCRIPTION
Note: it seems like there isn't a Chakra UI prop for the `:not([data-focus-visible-added])` selector, so I provided it as a string in `modal.ts`.